### PR TITLE
Fix UnitBuff error caused by API change in patch 7.3.5 and updated TOC

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -469,7 +469,7 @@ end
 function Addon:UPDATE_OVERRIDE_ACTIONBAR()
 	local inCamera = false
 	for i = 1, #cameraBuffs do
-		if UnitBuff("player", cameraBuffs[i]) then
+		if cameraBuffs[i] and UnitBuff("player", cameraBuffs[i]) then
 			inCamera = true
 			break
 		end

--- a/HandyNotes_FieldPhotographer.toc
+++ b/HandyNotes_FieldPhotographer.toc
@@ -1,4 +1,4 @@
-## Interface: 70100
+## Interface: 70300
 ## Version: @project-version@
 
 ## Title: HandyNotes: Field Photographer


### PR DESCRIPTION
 Fixed UnitBuff() error. WoW API no longer allows nil for the second parameter.

Updated TOC to 70300